### PR TITLE
Fix sending Slack messages which contain "/"

### DIFF
--- a/modules/notify-slack.sh
+++ b/modules/notify-slack.sh
@@ -44,6 +44,4 @@ fi
 
 SLACK_MESSAGE=`echo $SLACK_MESSAGE | sed "s/\"/'/g"`
 
-curl -s \
-  -d "payload={\"text\":\"$SLACK_MESSAGE\"}" \
-  $SLACK_WEBHOOK_URL
+curl -X POST -s --data-urlencode "payload={\"text\":\"$SLACK_MESSAGE\"}" $SLACK_WEBHOOK_URL


### PR DESCRIPTION
Use `--data-urlencode` argument for `curl`
