### PR TITLE
Fix getting changelog by using $CURRENT_VERSION

### DIFF
--- a/modules/notify-slack.sh
+++ b/modules/notify-slack.sh
@@ -24,13 +24,9 @@ USER=`git config user.name`
 SLACK_MESSAGE="\`$COMMAND/$CURRENT_VERSION\` $ACTION by $USER"
 
 if [[ $ACTION == "finished" ]]; then
-  VERSION_CURRENT=$(__get_current_version)
-
-  VERSION_PREFIX=$(git config --get gitflow.prefix.versiontag)
-  VERSION="$VERSION_PREFIX$VERSION_CURRENT"
   PREV_VERSION=$(git describe --abbrev=0 --tags $(git rev-list --tags --max-count=2) | $VERSION_SORT -V | head -1)
 
-  CHANGES=$(git log --no-merges --pretty=format:"%s (%an)\n" "$VERSION"..."$PREV_VERSION")
+  CHANGES=$(git log --no-merges --pretty=format:"%s (%an)\n" "$CURRENT_VERSION"..."$PREV_VERSION")
   SLACK_MESSAGE="$SLACK_MESSAGE\n\nChanges:\n$CHANGES"
 fi
 


### PR DESCRIPTION
Sometimes `__get_current_version` doesn't work as `git config --get gitflow.prefix.versiontag` is empty by default. To fix getting changes I would suggest using `$CURRENT_VERSION` argument variable.
